### PR TITLE
Update get_cert to use ssh rather than files

### DIFF
--- a/setup-app.py
+++ b/setup-app.py
@@ -32,7 +32,8 @@ def get_cert(appname, domain, certname):
     working directory with the same name that the certificate had on the
     server.
     """
-    command = "cf files %s app/conf/live/%s/%s" % (appname, domain, certname)
+    # command = "cf files %s app/conf/live/%s/%s" % (appname, domain, certname)
+    command = "cf ssh %s -c 'cat ~/app/conf/live/%s/%s'" % (appname, domain, certname)
     print("Running: %s" % command)
     pipe = Popen(command, shell=True, stdout=PIPE)
     output = pipe.stdout.readlines()


### PR DESCRIPTION
This should work with Diego since `cf files` is no longer supported