### PR TITLE
upped memory requirement to solve sporadic out of memory crashes

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,7 +1,7 @@
 applications:
   - name: letsencrypt
     buildpack: python_buildpack
-    memory: 64M
+    memory: 128M
     instances: 1
     no-hostname: true
     no-route: true


### PR DESCRIPTION
Sometimes the certificates would be generated, and digging into the logs would show
`Exit status 137 (out of memory)`
Easily fixed by giving it a bit more ram.