### PR TITLE
Fix cf --quiet option that changed in ibmcloud CLI 1.1.0

### DIFF
--- a/setup-app.py
+++ b/setup-app.py
@@ -30,7 +30,7 @@ def get_cert(appname, domain, certname):
     It then writes the certificate to a file in the current working
     directory with the same name that the certificate had on the server.
     """
-    command = "ibmcloud --quiet cf ssh %s -c \"cat ~/app/conf/live/%s/%s\"" % (appname, domain, certname)
+    command = "ibmcloud cf --quiet ssh %s -c \"cat ~/app/conf/live/%s/%s\"" % (appname, domain, certname)
     print("Running: %s" % command)
     certfile = open(certname,"w+")
     return Popen(command, shell=True, stdout=certfile)


### PR DESCRIPTION
Fix for https://github.com/ibmjstart/bluemix-letsencrypt/issues/32

Tested successfully : 
```
Parsing log files.
Waiting for certs...
Certs not ready yet, retrying in 5 seconds.
Certs not ready yet, retrying in 5 seconds.
Certs not ready yet, retrying in 5 seconds.

Waiting for container to mount filesystem
Running: ibmcloud cf --quiet ssh letsencrypt -c "cat ~/app/conf/live/domain.com/cert.pem"
Running: ibmcloud cf --quiet ssh letsencrypt -c "cat ~/app/conf/live/domain.com/chain.pem"
Running: ibmcloud cf --quiet ssh letsencrypt -c "cat ~/app/conf/live/domain.com/fullchain.pem"
Running: ibmcloud cf --quiet ssh letsencrypt -c "cat ~/app/conf/live/domain.com/privkey.pem"
Getting certificate info of domain domain.com in region eu-de...
OK
```
